### PR TITLE
Add simple error handling

### DIFF
--- a/app.js
+++ b/app.js
@@ -61,6 +61,7 @@ const routes = require('./routes/index')(app, passport); // load our routes and 
 
 // error handler
 app.use(function(err, req, res, next) {
+	console.error(err);
   res.status(err.status || 500).send({error: err.message});
 });
 

--- a/app.js
+++ b/app.js
@@ -7,10 +7,12 @@ const cookieParser = require('cookie-parser');
 const bodyParser = require('body-parser');
 
 //For database
+const mongoose = require('mongoose');
+const mongodbErrorHandler = require('mongoose-mongodb-errors');
+mongoose.plugin(mongodbErrorHandler);
+mongoose.Promise = require('bluebird');
 const users = require('./models/userModel.js');
 const opportunity = require('./models/opportunityModel.js');
-const mongoose = require('mongoose');
-mongoose.Promise = require('bluebird');
 
 //For passport OAuth
 const session      = require('express-session');
@@ -51,21 +53,15 @@ const routes = require('./routes/index')(app, passport); // load our routes and 
 //app.use('/', routes);
 
 // catch 404 and forward to error handler
-app.use(function(req, res, next) {
-  var err = new Error('Not Found');
-  err.status = 404;
-  next(err);
-});
+// app.use(function(req, res, next) {
+//   var err = new Error('Not Found');
+//   err.status = 404;
+//   next(err);
+// });
 
 // error handler
 app.use(function(err, req, res, next) {
-  // set locals, only providing error in development
-  res.locals.message = err.message;
-  res.locals.error = req.app.get('env') === 'development' ? err : {};
-
-  // render the error page
-  res.status(err.status || 500);
-  res.render('error');
+  res.status(err.status || 500).send({error: err.message});
 });
 
 module.exports = app;


### PR DESCRIPTION
Just adds `mongoose-mongodb-errors` package, and adds a simple error-handling middleware after the routes.

Made as pull request, so it can be discussed (in slack channel?) before added to master.